### PR TITLE
bug fix in endtime setting of trace

### DIFF
--- a/athina_logger/tracing/span.py
+++ b/athina_logger/tracing/span.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Any, Dict, List, Optional, Union
 from .models import SpanModel
-from .util import remove_none_values
+from .util import get_utc_end_time, remove_none_values
 
 class Span:
 
@@ -175,7 +175,7 @@ class Span:
             self._span.attributes.update(attributes)
 
     def end(self, end_time: Optional[datetime.datetime] = None):
-        end_time = end_time or datetime.datetime.utcnow()
+        end_time = get_utc_end_time(end_time)
         if self._span.end_time is None:
             self._span.end_time = end_time.isoformat()
         if self._span.duration is None:

--- a/athina_logger/tracing/trace.py
+++ b/athina_logger/tracing/trace.py
@@ -173,8 +173,9 @@ class Trace(AthinaApiKey):
             "athina-api-key": Trace.get_api_key(), "Content-Type": "application/json"
         })
 
-    def end(self, end_time: Optional[datetime.datetime] = datetime.datetime.utcnow()):
+    def end(self, end_time: Optional[datetime.datetime] = None):
         try:
+            end_time = end_time or datetime.datetime.utcnow()
             for span in self._spans:
                 span.end(end_time)
             if self._trace.end_time is None:

--- a/athina_logger/tracing/trace.py
+++ b/athina_logger/tracing/trace.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from .span import Generation, Span
 from .models import TraceModel
-from .util import remove_none_values
+from .util import get_utc_end_time, remove_none_values
 from athina_logger.api_key import AthinaApiKey
 from athina_logger.constants import API_BASE_URL
 from athina_logger.request_helper import RequestHelper
@@ -174,12 +174,12 @@ class Trace(AthinaApiKey):
         })
 
     def end(self, end_time: Optional[datetime.datetime] = None):
-        try:
-            end_time = end_time or datetime.datetime.utcnow()
+        try:      
+            end_time = get_utc_end_time(end_time)
             for span in self._spans:
                 span.end(end_time)
             if self._trace.end_time is None:
-                self._trace.end_time = end_time.utcnow().isoformat()
+                self._trace.end_time = end_time.isoformat()
             if self._trace.duration is None:
                 self._trace.duration = int((end_time - datetime.datetime.fromisoformat(self._trace.start_time)).total_seconds())
             request_dict = remove_none_values(self.to_dict())

--- a/athina_logger/tracing/util.py
+++ b/athina_logger/tracing/util.py
@@ -1,3 +1,6 @@
+from datetime import datetime, timezone
+
+
 def remove_none_values(d):
     if isinstance(d, dict):
         return {k: remove_none_values(v) for k, v in d.items() if v is not None}
@@ -5,3 +8,13 @@ def remove_none_values(d):
         return [remove_none_values(v) for v in d if v is not None]
     else:
         return d
+
+
+def get_utc_end_time(end_time):
+    if end_time is not None:
+        if end_time.tzinfo is None:
+            end_time = end_time.replace(tzinfo=timezone.utc)
+        end_time = end_time.astimezone(timezone.utc)
+    else:
+        end_time = datetime.now(timezone.utc)      
+    return end_time


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved the trace logging by automatically setting the end time to the current time if not specified.
- **Refactor**
	- Modified the `end` method in `trace.py` to handle end time processing more efficiently.
	- Updated the `update` method in `span.py` to merge attributes and improved end time handling.
- **New Features**
	- Added a new function `get_utc_end_time` in `util.py` to convert end time to UTC if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->