### PR TITLE
fixing context in langchain handler

### DIFF
--- a/athina_logger/langchain_handler.py
+++ b/athina_logger/langchain_handler.py
@@ -67,15 +67,13 @@ class CallbackHandler(BaseCallbackHandler, AthinaApiKey):
         **kwargs: Any,
     ) -> Any:
         try:
-            if run_id is None or run_id not in self.runs:
-                return
-            run_info = self.runs[run_id]
             retrieved_documents_data = ''
             for document in documents:
                 page_content = document.page_content
                 retrieved_documents_data += page_content + '\n'
+            if self.global_context is None:
+                self.global_context = {}
             self.global_context['documents'] = retrieved_documents_data
-            run_info['retrieved_documents'] = self.global_context
         except Exception as e:
             exception_message = (
                 f"Error:\n"


### PR DESCRIPTION
This was tested using 
``` python
import os
from dotenv import load_dotenv
load_dotenv()

from langchain.chains import RetrievalQA
from langchain.embeddings import OpenAIEmbeddings
from langchain.vectorstores import Chroma
from langchain.document_loaders import WebBaseLoader
from langchain.text_splitter import RecursiveCharacterTextSplitter
from langchain.embeddings import OpenAIEmbeddings
from langchain.vectorstores import Chroma
from langchain.chat_models import ChatOpenAI
from langchain.chains import RetrievalQA
from langchain import hub
from langchain.schema.document import Document

from athina_logger.api_key import AthinaApiKey
from athina_logger.langchain_handler import CallbackHandler
 
AthinaApiKey.set_api_key(os.getenv('ATHINA_API_KEY'))


# Loads the latest version
prompt = hub.pull("rlm/rag-prompt", api_url="https://api.hub.langchain.com")

loader = WebBaseLoader("https://lilianweng.github.io/posts/2023-06-23-agent/")
data = loader.load()

# Split
text_splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=0)
all_splits = text_splitter.split_documents(data)

# Store splits
vectorstore = Chroma.from_documents(documents=all_splits, embedding=OpenAIEmbeddings())

question = "How to Task Decomposition?"

athina_handler = CallbackHandler(
  prompt_slug='customer-query-prompt/v1',
  user_query=question,
  environment='production',
  session_id='1234',
  customer_id='nike-usa',
  customer_user_id='tim@apple.com',
  external_reference_id='your-reference-id',
  custom_attributes= {
      "loggedBy": "John Doe",
      "age": 24
  }
)

from langchain.callbacks.base import BaseCallbackHandler
from typing import Dict, Any, List, Union
from typing import Any, Dict, List, Optional, Tuple, Union, Sequence
from uuid import UUID
from langchain.schema.messages import (
    BaseMessage,
)


callbacks = [athina_handler]

# LLM
llm = ChatOpenAI(model_name="gpt-3.5-turbo", temperature=0)

# RetrievalQA
qa_chain = RetrievalQA.from_llm(
    llm, retriever=vectorstore.as_retriever(), prompt=prompt
)

result = qa_chain.invoke({"query": question}, { "callbacks" : callbacks })
print(result["result"])
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of global context initialization to ensure document data is correctly updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->