### PR TITLE
[docs] create makefile and contributions guide with install instructions

### DIFF
--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -10,3 +10,8 @@ Then, run
 make build
 ```
 to create the venv and install the requirements in it. 
+
+now you can run the below command to activate your virtual environment. 
+```bash
+source venv/bin/activate 
+```

--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -1,0 +1,12 @@
+# installation
+to install we need python3.9. Run 
+```
+make setup
+```
+to install python3.9 on mac. 
+
+Then, run 
+```
+make build
+```
+to create the venv and install the requirements in it. 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+# display help for each command
+help:
+	@echo "Available commands:"
+	@echo "  setup  - installs python@3.9 using brew"
+	@echo "  venv   - creates a virtual environment in ./venv"
+	@echo "  build  - activates venv, installs poetry, and sets up dependencies"
+
+# setup the development environment by installing python
+setup:
+	brew install python@3.9
+
+# create a virtual environment
+venv:
+	python3.9 -m venv venv
+
+# activate venv, install poetry, and set up dependencies
+build: venv
+	. ./venv/bin/activate && \
+	pip install poetry && \
+	poetry install
+
+# remove the virtual environment
+clean:
+	rm -rf venv


### PR DESCRIPTION
I've added a contributions guide with install instructions. 

The install instructions reference a new makefile I created with the commands to set this repo up on macos with python. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a Makefile for streamlined setup and management of a Python development environment.
	- Added installation instructions for setting up Python 3.9 on macOS.
	- Commands for creating a virtual environment and managing dependencies are now available.

- **Documentation**
	- Updated installation instructions in `CONTRIBUTIONS.md` for user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->