### PR TITLE
[feature] add model options to python sdk

### DIFF
--- a/athina_logger/inference_logger.py
+++ b/athina_logger/inference_logger.py
@@ -1,48 +1,100 @@
-import requests
-from typing import List, Optional, Dict, Union, Any
-from .constants import API_BASE_URL
-from .api_key import AthinaApiKey
-from .request_helper import RequestHelper
 import asyncio
 import threading
+from typing import List, Optional, Dict, Union, Any
+
+from .api_key import AthinaApiKey
+from .constants import API_BASE_URL
+from .request_helper import RequestHelper
+
 
 class InferenceLogger(AthinaApiKey):
 
     @staticmethod
     def log_inference(
-        prompt: Optional[Union[List[Dict[str, Any]], Dict[str, Any], str]] = None,
-        response: Optional[Any] = None,
-        prompt_slug: Optional[str] = None,
-        language_model_id: Optional[str] = None,
-        environment: Optional[str] = 'production',
-        functions: Optional[List[Dict]] = None,
-        function_call_response: Optional[Any] = None,
-        tools: Optional[Any] = None,
-        tool_calls: Optional[Any] = None,
-        external_reference_id: Optional[str] = None,
-        customer_id: Optional[str] = None,
-        customer_user_id: Optional[str] = None,
-        session_id: Optional[str] = None,
-        user_query: Optional[str] = None,
-        prompt_tokens: Optional[int] = None,
-        completion_tokens: Optional[int] = None,
-        total_tokens: Optional[int] = None,
-        response_time: Optional[int] = None,
-        context: Optional[Dict] = None,
-        expected_response: Optional[str] = None,
-        custom_attributes: Optional[Dict] = None,
-        custom_eval_metrics: Optional[Dict] = None,
-        cost: Optional[float] = None,
+            prompt: Optional[Union[List[Dict[str, Any]], Dict[str, Any], str]] = None,
+            response: Optional[Any] = None,
+            prompt_slug: Optional[str] = None,
+            language_model_id: Optional[str] = None,
+            environment: Optional[str] = 'production',
+            functions: Optional[List[Dict]] = None,
+            function_call_response: Optional[Any] = None,
+            tools: Optional[Any] = None,
+            tool_calls: Optional[Any] = None,
+            external_reference_id: Optional[str] = None,
+            customer_id: Optional[str] = None,
+            customer_user_id: Optional[str] = None,
+            session_id: Optional[str] = None,
+            user_query: Optional[str] = None,
+            prompt_tokens: Optional[int] = None,
+            completion_tokens: Optional[int] = None,
+            total_tokens: Optional[int] = None,
+            response_time: Optional[int] = None,
+            context: Optional[Dict] = None,
+            expected_response: Optional[str] = None,
+            custom_attributes: Optional[Dict] = None,
+            custom_eval_metrics: Optional[Dict] = None,
+            cost: Optional[float] = None,
+            model_options: Optional[dict] = None,
     ) -> None:
+        """
+            logs prompt run data to athina.
+
+            asynchronously logs structured inference data, safe for performance-critical code.
+            errors are suppressed and printed.
+
+            Parameters:
+            - prompt (Union[List[Dict[str, Any]], Dict[str, Any], str], optional): The main prompt or message data, supporting string or structured list of messages.
+            - response (Any, optional): The response to the prompt, can be of any type.
+            - prompt_slug (str, optional): Unique slug identifying the prompt type.
+            - language_model_id (str, optional): Identifier for the language model used.
+            - environment (str, optional): Operational environment, e.g., 'production' or 'development'.
+            - functions (List[Dict[str, Any]], optional): Functions metadata used in processing, as an array of function schemas.
+            - function_call_response (Any, optional): Response object or data resulting from function calls.
+            - tools (Any, optional): Metadata for tools used in inference, if any.
+            - tool_calls (Any, optional): Metadata for tool call results.
+            - external_reference_id (str, optional): External reference for tracking, nullable.
+            - customer_id (str, optional): Identifier for the customer using the service, nullable.
+            - customer_user_id (str, optional): Unique user identifier for the customer’s user, nullable.
+            - session_id (str, optional): ID for the current session, nullable.
+            - user_query (str, optional): Original query from the user, nullable.
+            - prompt_tokens (int, optional): Number of tokens in the prompt input.
+            - completion_tokens (int, optional): Number of tokens in the model’s output completion.
+            - total_tokens (int, optional): Sum of tokens used (prompt + completion).
+            - response_time (int, optional): Time taken to generate a response, in milliseconds.
+            - context (Union[Dict[str, Any], str], optional): Additional context data as a dictionary or string, nullable.
+            - expected_response (str, optional): The expected response for comparison or validation, nullable.
+            - custom_attributes (Dict[str, Any], optional): Additional attributes for custom data, structured as key-value pairs.
+            - custom_eval_metrics (Dict[str, Any], optional): Custom evaluation metrics for assessing response quality.
+            - cost (float, optional): Inference cost, if calculated.
+            - model_options (Dict[str, Any], optional): Configuration options for the model run, including:
+              - `temperature` (float, optional): Sampling temperature.
+              - `max_completion_tokens` (int, optional): Maximum tokens allowed in response.
+              - `stop` (Union[str, List[str]], optional): Stop sequence(s) to halt generation.
+              - `top_p` (float, optional): Top-p sampling parameter.
+              - `extra_options` (Dict[str, Any], optional): Any additional options for model customization.
+
+            Returns:
+            - None: The method does not return any value.
+
+            Raises:
+            - None: errors are suppressed and printed.
+            """
         try:
-            args = (prompt, response, prompt_slug, language_model_id, environment, functions, function_call_response, tools, tool_calls, external_reference_id, customer_id, customer_user_id, session_id, user_query, prompt_tokens, completion_tokens, total_tokens, response_time, context, expected_response, custom_attributes, cost, custom_eval_metrics)
+            args = (
+                prompt, response, prompt_slug, language_model_id, environment, functions, function_call_response, tools,
+                tool_calls, external_reference_id, customer_id, customer_user_id, session_id, user_query, prompt_tokens,
+                completion_tokens, total_tokens, response_time, context, expected_response, custom_attributes, cost,
+                custom_eval_metrics, model_options)
             threading.Thread(target=lambda: asyncio.run(InferenceLogger._log_inference_asynchronously(*args))).start()
         except Exception as e:
             print("Error in logging inference to Athina: ", str(e))
 
     @staticmethod
     async def _log_inference_asynchronously(
-        prompt, response, prompt_slug, language_model_id, environment, functions, function_call_response, tools, tool_calls, external_reference_id, customer_id, customer_user_id, session_id, user_query, prompt_tokens, completion_tokens, total_tokens, response_time, context, expected_response, custom_attributes, cost, custom_eval_metrics
+            prompt, response, prompt_slug, language_model_id, environment, functions, function_call_response, tools,
+            tool_calls, external_reference_id, customer_id, customer_user_id, session_id, user_query, prompt_tokens,
+            completion_tokens, total_tokens, response_time, context, expected_response, custom_attributes, cost,
+            custom_eval_metrics, model_options
     ) -> None:
         """
         logs the llm inference to athina
@@ -72,6 +124,7 @@ class InferenceLogger(AthinaApiKey):
                 'custom_attributes': custom_attributes,
                 'custom_eval_metrics': custom_eval_metrics,
                 'cost': cost,
+                'model_options': model_options,
             }
             # Remove None fields from the payload
             payload = {k: v for k, v in payload.items() if v is not None}

--- a/tests/test_inference_logger.py
+++ b/tests/test_inference_logger.py
@@ -125,7 +125,7 @@ def test_log_inference_no_model_options(
         ),
     ]
 )
-def test_log_inference_with_model_options(
+def test_log_inference_with_model_options_none(
         language_model_id, prompt, response, user_query, context, prompt_tokens,
         completion_tokens, total_tokens, cost, response_time, prompt_slug, environment,
         customer_id, customer_user_id, session_id, expected_response, tools, tool_calls,
@@ -158,5 +158,5 @@ def test_log_inference_with_model_options(
         function_call_response=function_call_response,
         external_reference_id=external_reference_id,
         custom_attributes=custom_attributes,
-        model_options=model_options
+        model_options=model_options,
     )

--- a/tests/test_inference_logger.py
+++ b/tests/test_inference_logger.py
@@ -160,3 +160,89 @@ def test_log_inference_with_model_options_none(
         custom_attributes=custom_attributes,
         model_options=model_options,
     )
+
+
+## these parameters are shared across the model_options tests
+default_params = {
+    "language_model_id": "gpt-4",
+    "prompt": [
+        {
+            "role": "system",
+            "content": "Answer the following question using the information provided.\n ### INFORMATION ### Neil Armstrong landed on the moon in 1969.\n ### QUERY ###"
+        },
+        {
+            "role": "user",
+            "content": "Which spaceship was first to land on the moon?"
+        }
+    ],
+    "response": "The Apollo 11 was the first spaceship to land on the moon.",
+    "user_query": "Which spaceship was first to land on the moon?",
+    "context": {"information": ["Neil Armstrong landed on the moon in 1969."]},
+    "prompt_tokens": 22,
+    "completion_tokens": 9,
+    "total_tokens": 31,
+    "cost": 0.002,
+    "response_time": 150,
+    "prompt_slug": "qa_chatbot_response",
+    "environment": "development",
+    "customer_id": "xyz-123",
+    "customer_user_id": "user-456",
+    "session_id": "session-789",
+    "expected_response": "The Apollo 11 was the first spaceship to land on the moon.",
+    "tools": [],
+    "tool_calls": None,
+    "functions": [],
+    "function_call_response": None,
+    "external_reference_id": "ref-101112",
+    "custom_attributes": {"company": "OpenAI", "links": ["https://openai.com"]},
+}
+
+
+@pytest.mark.parametrize("model_options", [
+    # no options provided
+    {},
+
+    # individual fields
+    {"temperature": 0.7},
+    {"max_completion_tokens": 150},
+    {"stop": "complete"},
+    {"stop": ["complete", "end"]},
+    {"top_p": 0.9},
+    {"extra_options": {"custom_option": "custom_value"}},
+
+    # combinations of fields
+    {"temperature": 0.7, "max_completion_tokens": 150},
+    {"temperature": 0.7, "stop": "complete"},
+    {"temperature": 0.7, "stop": ["complete", "end"]},
+    {"temperature": 0.7, "top_p": 0.9},
+    {"temperature": 0.7, "extra_options": {"custom_option": "custom_value"}},
+
+    {"max_completion_tokens": 150, "stop": "complete"},
+    {"max_completion_tokens": 150, "stop": ["complete", "end"]},
+    {"max_completion_tokens": 150, "top_p": 0.9},
+    {"max_completion_tokens": 150, "extra_options": {"another_option": 123}},
+
+    {"stop": "complete", "top_p": 0.9},
+    {"stop": ["complete", "end"], "top_p": 0.9},
+    {"stop": "complete", "extra_options": {"flag": True}},
+    {"stop": ["complete", "end"], "extra_options": {"flag": True}},
+
+    {"top_p": 0.9, "extra_options": {"threshold": 0.5}},
+
+    # all fields filled
+    {
+        "temperature": 0.7,
+        "max_completion_tokens": 150,
+        "stop": ["complete", "end"],
+        "top_p": 0.9,
+        "extra_options": {"custom_key": "custom_value"}
+    },
+])
+def test_log_inference_with_model_options_not_none(model_options):
+    athina_api_key = os.getenv("ATHINA_API_KEY")
+    AthinaApiKey.set_api_key(api_key=athina_api_key)
+
+    test_params = {**default_params, "model_options": model_options}
+
+    InferenceLogger.log_inference(**test_params)
+    pass

--- a/tests/test_inference_logger.py
+++ b/tests/test_inference_logger.py
@@ -12,7 +12,6 @@ from athina_logger.inference_logger import InferenceLogger
     "customer_id, customer_user_id, session_id, expected_response, tools, tool_calls, "
     "functions, function_call_response, external_reference_id, custom_attributes",
     [
-        # smoke test with all fields in the sdk param.
         (
                 "gpt-4",
                 [
@@ -48,7 +47,7 @@ from athina_logger.inference_logger import InferenceLogger
         ),
     ]
 )
-def test_log_inference(
+def test_log_inference_no_model_options(
         language_model_id, prompt, response, user_query, context, prompt_tokens,
         completion_tokens, total_tokens, cost, response_time, prompt_slug, environment,
         customer_id, customer_user_id, session_id, expected_response, tools, tool_calls,
@@ -81,4 +80,83 @@ def test_log_inference(
         function_call_response=function_call_response,
         external_reference_id=external_reference_id,
         custom_attributes=custom_attributes,
+    )
+
+
+@pytest.mark.parametrize(
+    "language_model_id, prompt, response, user_query, context, prompt_tokens, "
+    "completion_tokens, total_tokens, cost, response_time, prompt_slug, environment, "
+    "customer_id, customer_user_id, session_id, expected_response, tools, tool_calls, "
+    "functions, function_call_response, external_reference_id, custom_attributes, model_options, ",
+    [
+        (
+                "gpt-4",
+                [
+                    {
+                        "role": "system",
+                        "content": "Answer the following question using the information provided.\n ### INFORMATION ### Neil Armstrong landed on the moon in 1969.\n ### QUERY ###"
+                    },
+                    {
+                        "role": "user",
+                        "content": "Which spaceship was first to land on the moon?"
+                    }
+                ],
+                "The Apollo 11 was the first spaceship to land on the moon.",
+                "Which spaceship was first to land on the moon?",
+                {"information": ["Neil Armstrong landed on the moon in 1969."]},
+                22,
+                9,
+                31,
+                0.002,
+                150,
+                "qa_chatbot_response",
+                "development",
+                "xyz-123",
+                "user-456",
+                "session-789",
+                "The Apollo 11 was the first spaceship to land on the moon.",
+                [],
+                None,
+                [],
+                None,
+                "ref-101112",
+                {"company": "OpenAI", "links": ["https://openai.com"]},
+                None
+        ),
+    ]
+)
+def test_log_inference_with_model_options(
+        language_model_id, prompt, response, user_query, context, prompt_tokens,
+        completion_tokens, total_tokens, cost, response_time, prompt_slug, environment,
+        customer_id, customer_user_id, session_id, expected_response, tools, tool_calls,
+        functions, function_call_response, external_reference_id, custom_attributes, model_options
+):
+    athina_api_key = os.getenv("ATHINA_API_KEY")
+
+    AthinaApiKey.set_api_key(api_key=athina_api_key)
+
+    InferenceLogger.log_inference(
+        language_model_id=language_model_id,
+        prompt=prompt,
+        response=response,
+        user_query=user_query,
+        context=context,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+        cost=cost,
+        response_time=response_time,
+        prompt_slug=prompt_slug,
+        environment=environment,
+        customer_id=customer_id,
+        customer_user_id=customer_user_id,
+        session_id=session_id,
+        expected_response=expected_response,
+        tools=tools,
+        tool_calls=tool_calls,
+        functions=functions,
+        function_call_response=function_call_response,
+        external_reference_id=external_reference_id,
+        custom_attributes=custom_attributes,
+        model_options=model_options
     )


### PR DESCRIPTION
This PR adds the new `mode_options` parameter in our api to the python logging sdk. 

This also includes integration tests for the new parameter that cover all of the options in it. 

I've also added a docstring to the api so people can see it in their editors. 

athina api pr: https://github.com/athina-ai/athina-api/pull/984/files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new parameter, `model_options`, for enhanced configuration during inference logging, allowing users to specify options like `temperature` and `max_completion_tokens`.
  
- **Bug Fixes**
	- Improved error handling and documentation for the `log_inference` method to clarify behavior.

- **Tests**
	- Expanded test coverage for `InferenceLogger` with new tests for logging inference using various model options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->